### PR TITLE
allow do define a 'responsible' string per bp that can be used in the…

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,11 @@ id: app_x
 # the availabilities section from the global configuration...? This links 
 # there.
 availability: 9to5
+# You can also specify a 'responsible' string. This string can then be used in
+# the trigger template. This could be for example trigger a specific http
+# end point, pass some uri parameters, send an email to a specific address etc.
+# The 'responsible' string is inherited by its KPIs if not overwritten...
+responsible: app.team@example.com
 # Now the KPIs...
 kpis:
   - 
@@ -161,6 +166,9 @@ kpis:
     #                 need to be 'OK'
     # * MINPERCENT x:  As 'MIN', but in percent.
     operation: OR
+    # Again, a 'responsible' string can be specified in order not to inherit
+    # from the parent BP.
+    responsible: infra.team@example.com
     # And now the processes. Host and service relate to how you named those
     # things in your Icinga2 setup.
     services:
@@ -170,7 +178,7 @@ kpis:
     id: app_availability
     operation: MINPERCENT 50
     services:
-      - { host: app1.example.com, service: api_health } 
+      - { host: app1.example.com, service: api_health, responsible: engineering.team@example.com }
       - { host: app2.example.com, service: api_health }
       - { host: app3.example.com, service: api_health }
       - { host: app4.example.com, service: api_health }

--- a/bp.go
+++ b/bp.go
@@ -32,7 +32,9 @@ func (bp BP) Status(ssp ServiceStatusProvider, pp PersistenceProvider, r rules.R
 	ch := make(chan *ResultSet)
 	var calcValues []bool
 	for _, k := range bp.Kpis {
-		k.Responsible = bp.Responsible
+		if k.Responsible == "" {
+			k.Responsible = bp.Responsible
+		}
 		go func(k KPI, ssp ServiceStatusProvider, pp PersistenceProvider, r rules.Rules) {
 			childRs := k.Status(ssp, pp, r)
 			ch <- &childRs
@@ -83,7 +85,9 @@ func (k KPI) Status(ssp ServiceStatusProvider, pp PersistenceProvider, r rules.R
 	ch := make(chan *ResultSet)
 	var calcValues []bool
 	for _, s := range k.Services {
-		s.Responsible = k.Responsible
+		if s.Responsible == "" {
+			s.Responsible = k.Responsible
+		}
 		go func(s Service, ssp ServiceStatusProvider, pp PersistenceProvider, r rules.Rules) {
 			childRs := s.Status(ssp, pp, r)
 			ch <- &childRs

--- a/cmd/bpmon/run.go
+++ b/cmd/bpmon/run.go
@@ -10,8 +10,9 @@ import (
 )
 
 var (
-	printTimestamps bool
-	printValues     bool
+	printTimestamps  bool
+	printValues      bool
+	printResponsible bool
 )
 
 var runCmd = &cobra.Command{
@@ -41,7 +42,7 @@ var runCmd = &cobra.Command{
 			if c.Influx.GetLastStatus {
 				rs.AddPreviousStatus(infl, c.Influx.SaveOK)
 			}
-			fmt.Println(rs.PrettyPrint(0, printTimestamps, printValues))
+			fmt.Println(rs.PrettyPrint(0, printTimestamps, printValues, printResponsible))
 		}
 	},
 }
@@ -49,5 +50,6 @@ var runCmd = &cobra.Command{
 func init() {
 	RootCmd.AddCommand(runCmd)
 	runCmd.PersistentFlags().BoolVarP(&printTimestamps, "ts", "t", false, "print timestamps of measurement")
-	runCmd.PersistentFlags().BoolVarP(&printValues, "vals", "v", false, "print raw  measurement results if available")
+	runCmd.PersistentFlags().BoolVarP(&printValues, "vals", "v", false, "print raw measurement results if available")
+	runCmd.PersistentFlags().BoolVarP(&printResponsible, "resp", "r", false, "print responsible of measurement")
 }

--- a/resultset.go
+++ b/resultset.go
@@ -29,7 +29,7 @@ type ResultSet struct {
 	Children      []*ResultSet
 }
 
-func (rs ResultSet) PrettyPrint(level int, ts bool, vals bool) string {
+func (rs ResultSet) PrettyPrint(level int, ts bool, vals bool, resp bool) string {
 	ident := strings.Repeat("   ", level)
 	out := rs.Status.Colorize(fmt.Sprintf("%s%s %s is %v", ident, rs.Kind, rs.Name, rs.Status))
 	if rs.WasChecked {
@@ -40,6 +40,9 @@ func (rs ResultSet) PrettyPrint(level int, ts bool, vals bool) string {
 	if ts {
 		timestamp := rs.At.Format("2006-01-02 15:04:05")
 		out += fmt.Sprintf(" (%s)", timestamp)
+	}
+	if resp {
+		out += fmt.Sprintf(" (Responsible: %s)", rs.Responsible)
 	}
 	if rs.Err != nil {
 		out += fmt.Sprintf("\n%sError occured: %s", ident, rs.Err.Error())
@@ -66,7 +69,7 @@ func (rs ResultSet) PrettyPrint(level int, ts bool, vals bool) string {
 	}
 	out += "\n"
 	for _, childRs := range rs.Children {
-		out += childRs.PrettyPrint(level+1, ts, vals)
+		out += childRs.PrettyPrint(level+1, ts, vals, resp)
 	}
 	return out
 }

--- a/resultset.go
+++ b/resultset.go
@@ -25,6 +25,7 @@ type ResultSet struct {
 	StatusChanged bool
 	Err           error
 	Output        string
+	Responsible   string
 	Children      []*ResultSet
 }
 


### PR DESCRIPTION
… trigger subcommand...

This change allows to define a 'responsible' field (handled as string) in the business Process definition which is passed to the resulting 'result set'. The 'result set' containing the responsible field can then be used in the template set for the trigger command which would allow for example to call up different organization units per business process... Which is nice if you have more than one entry point for "on-duty alerts".