### PR TITLE
allow to read recipients from http headers

### DIFF
--- a/bp.go
+++ b/bp.go
@@ -32,12 +32,14 @@ func (bps BusinessProcesses) GenerateRecipientHashes(pepper string) map[string]s
 	return recipients
 }
 
-func (bps BusinessProcesses) GetByRecipient(recipient string) BusinessProcesses {
+func (bps BusinessProcesses) GetByRecipients(recipients []string) BusinessProcesses {
 	var out BusinessProcesses
 	for _, bp := range bps {
 		for _, r := range bp.Recipients {
-			if recipient == r {
-				out = append(out, bp)
+			for _, recipient := range recipients {
+				if recipient == r {
+					out = append(out, bp)
+				}
 			}
 		}
 	}

--- a/periphery/dashboard/api_handler.go
+++ b/periphery/dashboard/api_handler.go
@@ -15,8 +15,8 @@ import (
 func ListBPsHandler(res http.ResponseWriter, req *http.Request) {
 	list := make(map[string]string)
 
-	if recipient := req.Context().Value(wh.KeyRecipient); recipient != nil {
-		for _, bp := range bps.GetByRecipient(recipient.(string)) {
+	if recipients := req.Context().Value(wh.KeyRecipients); recipients != nil {
+		for _, bp := range bps.GetByRecipients(recipients.([]string)) {
 			list[bp.ID] = bp.Name
 		}
 	} else {

--- a/periphery/dashboard/dashboard.go
+++ b/periphery/dashboard/dashboard.go
@@ -19,7 +19,7 @@ var pp store.Accessor
 
 var routes = make(map[string]wh.Leafs)
 
-func Setup(conf configs.DashboardConf, bpsIn bpmon.BusinessProcesses, ppIn store.Accessor, auth bool, recipientHashes map[string]string) (http.Handler, error) {
+func Setup(conf configs.DashboardConf, bpsIn bpmon.BusinessProcesses, ppIn store.Accessor, tokenAuth bool, recipientHashes map[string]string, recipientsHeaderAuth bool, recipientsHeaderName string) (http.Handler, error) {
 	pp = ppIn
 	bps = bpsIn
 
@@ -28,9 +28,11 @@ func Setup(conf configs.DashboardConf, bpsIn bpmon.BusinessProcesses, ppIn store
 	apiRouter := mux.NewRouter()
 	api := apiRouter.PathPrefix("/api/").Subrouter()
 	wh.PopulateRouter(api, routes)
-	if auth {
+	if tokenAuth {
 		ta := wh.TokenAuth{Tokens: recipientHashes}
 		r.Handle("/api/{_:.*}", ta.Create(apiRouter))
+	} else if recipientsHeaderAuth {
+		r.Handle("/api/{_:.*}", wh.RecipientsHeaderAuth(apiRouter, recipientsHeaderName))
 	} else {
 		r.Handle("/api/{_:.*}", apiRouter)
 	}


### PR DESCRIPTION
This PR allows to pass the `--recipients-header` option to the `beta dashboard` subcommand and read the recipients from a specified http header. This allows for example to place bpmon behind a keycloak-proxy (https://github.com/gambol99/keycloak-proxy) for authentification and use the generate 'X-Auth-Groups' header do grant access do BPs via 'recipients' in the BP definition.